### PR TITLE
fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 import os
 from setuptools import setup, find_packages
 
-BASE_DIR = os.path.abspath(path.dirname(__file__))
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(BASE_DIR, 'README.rst'), encoding='utf-8') as f:
+with open(os.path.join(BASE_DIR, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
* Nonexistent `README.rst` -> `README.md`
* `path` -> `os.path`